### PR TITLE
feat(ci): publish Playwright report previews to GitHub Pages per-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+    types: [opened, reopened, synchronize, closed]
 
 concurrency:
   group:
@@ -15,6 +16,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event.action != 'closed'
 
     steps:
       - name: Check out code
@@ -44,6 +46,7 @@ jobs:
   playwright:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    if: github.event.action != 'closed'
 
     steps:
       - name: Check out code
@@ -73,6 +76,57 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+  publish-report:
+    runs-on: ubuntu-latest
+    needs: [playwright]
+    if: >-
+      github.event_name == 'pull_request' && github.event.action != 'closed' &&
+      !cancelled()
+    concurrency:
+      group: pages-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Download Playwright report
+        uses: actions/download-artifact@v6
+        with:
+          name: playwright-report
+          path: playwright-report/
+
+      - name: Publish report to GitHub Pages
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: playwright-report/
+          action: deploy
+
+  cleanup-report:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    concurrency:
+      group: pages-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+
+      - name: Remove report preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: playwright-report/
+          action: remove
 
   deploy-preview:
     runs-on: ubuntu-latest

--- a/docs/facets/README.md
+++ b/docs/facets/README.md
@@ -95,6 +95,8 @@ your app doesn't need it.
   for generating test data.
 - [e2e-testing](./e2e-testing.md) — Playwright E2E tests with axe-core
   accessibility checks against the preview build.
+- [user-review](./user-review.md) — Per-PR Playwright report previews on GitHub
+  Pages with embedded trace viewer.
 
 ## Infrastructure
 

--- a/docs/facets/user-review.md
+++ b/docs/facets/user-review.md
@@ -1,0 +1,45 @@
+# User Review
+
+Per-PR Playwright HTML report previews on GitHub Pages with embedded trace
+viewer.
+
+## Description
+
+When a pull request runs Playwright E2E tests, the CI workflow publishes the
+HTML report (including the embedded trace viewer) to GitHub Pages. A bot comment
+is posted on the PR with a direct link to the report. When the PR is closed or
+merged, the report is automatically cleaned up.
+
+## How it works
+
+1. The `playwright` job runs tests and uploads `playwright-report/` as an
+   artifact (existing behavior)
+2. The `publish-report` job downloads the artifact and uses
+   `rossjrw/pr-preview-action@v1` to push it to the `gh-pages` branch under
+   `pr-preview/pr-<N>/`
+3. The action posts a sticky PR comment with the preview URL
+4. The embedded trace viewer works same-origin on GitHub Pages — no CORS issues,
+   works for private repos too
+5. On PR close, the `cleanup-report` job removes the preview directory from
+   `gh-pages`
+
+## Related Files
+
+- `.github/workflows/ci.yml` — `publish-report` and `cleanup-report` jobs
+- `playwright.config.ts` — Trace and reporter settings
+
+## One-time setup
+
+See `docs/operations/setup.md` for GitHub Pages configuration:
+
+- Enable GitHub Pages to deploy from the `gh-pages` branch
+- Grant workflow read-and-write permissions
+
+## Removal
+
+1. Delete the `publish-report` and `cleanup-report` jobs from
+   `.github/workflows/ci.yml`
+2. Remove the `closed` type from the `pull_request` trigger (if no other job
+   needs it)
+3. Disable GitHub Pages in repository settings
+4. Delete this file and its entry in `docs/facets/README.md`

--- a/docs/operations/setup.md
+++ b/docs/operations/setup.md
@@ -48,20 +48,58 @@ The deployment jobs are disabled by default. To enable them:
 
 1. Open `.github/workflows/ci.yml`
 2. For **Preview Deployments** (PR previews):
-   - Change line 57 from `if: false` to:
+   - Find the `deploy-preview` job and change its `if: false` to:
      ```yaml
      if: github.event_name == 'pull_request'
      ```
    - Remove or comment out the `if: false` line
 
 3. For **Production Deployments**:
-   - Change line 112 from `if: false` to:
+   - Find the `deploy-production` job and change its `if: false` to:
      ```yaml
      if:
        github.event_name == 'push' && (github.ref == 'refs/heads/main' ||
        github.ref == 'refs/heads/master')
      ```
    - Remove or comment out the `if: false` line
+
+### Step 2b: Enable Playwright Report Previews (Optional)
+
+The CI workflow can publish Playwright HTML reports (with embedded trace viewer)
+to GitHub Pages per-PR. Reviewers get a clickable link in a PR comment instead
+of downloading artifacts.
+
+#### Enable GitHub Pages
+
+1. Go to **Settings** → **Pages**
+2. Under **Build and deployment**, set **Source** to **Deploy from a branch**
+3. Set **Branch** to `gh-pages` and folder to `/ (root)`
+4. Click **Save**
+
+The `gh-pages` branch is created automatically on the first report publish.
+
+#### Grant Workflow Permissions
+
+1. Go to **Settings** → **Actions** → **General**
+2. Under **Workflow permissions**, select **Read and write permissions**
+3. Click **Save**
+
+#### How It Works
+
+- The `publish-report` job downloads the Playwright report artifact and pushes
+  it to `gh-pages` under `pr-preview/pr-<N>/`
+- `rossjrw/pr-preview-action` posts a sticky PR comment with the preview URL
+- On PR close, the `cleanup-report` job removes the preview directory
+
+#### Troubleshooting
+
+- **404 on preview link**: GitHub Pages may take 1-2 minutes to deploy after the
+  job completes. If the `gh-pages` branch doesn't exist yet, the first publish
+  creates it automatically.
+- **Permission denied**: Verify workflow permissions are set to "Read and write"
+  in repository settings.
+- **Report not updating**: Check the `publish-report` job logs. The concurrency
+  group prevents overlapping pushes — wait for the previous run to finish.
 
 ### Step 3: Verify Workflow
 


### PR DESCRIPTION
Add PR event type filtering, job guards for non-closed events, and two new jobs (publish-report, cleanup-report) that deploy and tear down per-PR Playwright HTML report previews via rossjrw/pr-preview-action.



docs: add user-review facet and GitHub Pages setup instructions

Create docs/facets/user-review.md describing the per-PR Playwright report preview feature, register it in the facets index, and document the GitHub Pages enablement steps in docs/operations/setup.md.



fix: address code review findings for PR report previews

- Add missing actions/checkout step in publish-report job (required by rossjrw/pr-preview-action)
- Replace stale hard-coded line numbers with job name references in setup.md deployment instructions
- Align facet section headings with project convention (Description, Related files) and use list format instead of table



fix: capitalize Related Files heading to match facet convention